### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Happy hacking!
 [zip-download]: https://cdn.jsdelivr.net/gh/julmot/datatables.mark.js/dist/
 [npm]: https://www.npmjs.com/
 [bower]: https://bower.io/
-[markjs-jsdelivr]: https://cdn.jsdelivr.net/gh/julmot/datatables.mark.js/dist/
+[markjs-jsdelivr]: https://www.jsdelivr.com/package/gh/julmot/datatables.mark.js
 [datatables-plugins-cdn]: https://cdn.datatables.net/plug-ins/
 [datatables-plugins-cdn-latest]: https://cdn.datatables.net/plug-ins/1.10.13/features/
 [markjs-jquery]: https://github.com/julmot/mark.js/blob/master/dist/jquery.mark.min.js

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Happy hacking!
 [zip-download]: https://cdn.jsdelivr.net/gh/julmot/datatables.mark.js/dist/
 [npm]: https://www.npmjs.com/
 [bower]: https://bower.io/
-[markjs-jsdelivr]: https://www.jsdelivr.com/package/gh/julmot/datatables.mark.js
+[markjs-jsdelivr]: https://cdn.jsdelivr.net/npm/datatables.mark.js/dist/datatables.mark.js
 [datatables-plugins-cdn]: https://cdn.datatables.net/plug-ins/
 [datatables-plugins-cdn-latest]: https://cdn.datatables.net/plug-ins/1.10.13/features/
 [markjs-jquery]: https://github.com/julmot/mark.js/blob/master/dist/jquery.mark.min.js

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Happy hacking!
 [zip-download]: https://cdn.jsdelivr.net/gh/julmot/datatables.mark.js/dist/
 [npm]: https://www.npmjs.com/
 [bower]: https://bower.io/
-[markjs-jsdelivr]: https://cdn.jsdelivr.net/npm/datatables.mark.js/dist/datatables.mark.js
+[markjs-jsdelivr]: https://www.jsdelivr.com/package/npm/datatables.mark.js?path=dist
 [datatables-plugins-cdn]: https://cdn.datatables.net/plug-ins/
 [datatables-plugins-cdn-latest]: https://cdn.datatables.net/plug-ins/1.10.13/features/
 [markjs-jquery]: https://github.com/julmot/mark.js/blob/master/dist/jquery.mark.min.js


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/julmot/datatables.mark.js.

Feel free to ping me if you have any questions regarding this change.